### PR TITLE
Change intermediate file location

### DIFF
--- a/R/riboseqc.R
+++ b/R/riboseqc.R
@@ -95,6 +95,9 @@ create_html_report <- function(input_files, input_sample_names, output_file,exte
         rmd_path <- paste(system.file(package="RiboseQC",mustWork = TRUE),"/rmd/riboseqc_template_full.Rmd",sep="")
     }
 
+    # set tmp folder outside Rpackage
+    tmp_dir = dirname(output_file)
+
     # get folder path for pdf figures
     output_fig_path <- paste(output_file,"_plots/", sep = "")
 
@@ -108,7 +111,8 @@ create_html_report <- function(input_files, input_sample_names, output_file,exte
            params = list(input_files = input_files,
                          input_sample_names = input_sample_names,
                          output_fig_path = output_fig_path),
-           output_file = output_file))
+           output_file = output_file,
+	   intermediates_dir = tmp_dir))
     gici<-gc()
     sink()
 }


### PR DESCRIPTION
@damhof 
Using R containers, the R package location is no longer writable for intermediate files (the standard location) and therefore the generation of the HTML fails. Adding a variable to intermediates_dir solves this issue.